### PR TITLE
Add JupyterLab

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
         - joblib
         - jupyter
         - jupyter_contrib_nbextensions
+        - jupyterlab
         - keras
         - line_profiler
         - matplotlib>=1.4


### PR DESCRIPTION
Apparently `jupyterlab` is not included in the `jupyter` core package